### PR TITLE
camera with rotors

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -5,6 +5,7 @@ pub enum WindowEvent {
     Resize(ResizeMessage),
     PointerMove(MouseMessage),
     PointerClick(MouseMessage),
+    PointerWheel(WheelMessage),
 }
 
 // Display for WindowEvent
@@ -14,6 +15,7 @@ impl fmt::Display for WindowEvent {
             WindowEvent::Resize(msg) => write!(f, "Resize: {:?}", msg),
             WindowEvent::PointerMove(msg) => write!(f, "PointerMove: {:?}", msg),
             WindowEvent::PointerClick(msg) => write!(f, "PointerClick: {:?}", msg),
+            WindowEvent::PointerWheel(msg) => write!(f, "PointerWheel: {:?}", msg),
         }
     }
 }
@@ -51,6 +53,32 @@ impl MouseMessage {
             movement_y: event.movement_y() as f64,
             offset_x: event.offset_x() as f64,
             offset_y: event.offset_y() as f64,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WheelMessage {
+    pub scale_factor: f64,
+    pub delta_x: f64,
+    pub delta_y: f64,
+    pub delta_z: f64,
+    pub delta_mode: u32,
+    pub client_x: f64,
+    pub client_y: f64,
+}
+
+impl WheelMessage {
+    pub fn from_evt(event: web_sys::WheelEvent) -> Self {
+        let window = web_sys::window().unwrap();
+        Self {
+            scale_factor: window.device_pixel_ratio(),
+            delta_x: event.delta_x(),
+            delta_y: event.delta_y(),
+            delta_z: event.delta_z(),
+            delta_mode: event.delta_mode(),
+            client_x: event.client_x() as f64,
+            client_y: event.client_y() as f64,
         }
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -455,6 +455,10 @@ impl Renderer {
                     log::error!("failed to load gltf: {e}");
                 }
             }
+            WindowEvent::PointerWheel(msg) => {
+                let mut r = renderer.borrow_mut();
+                r.scene.cam.zoom(&msg);
+            }
         }
     }
 


### PR DESCRIPTION
add initial implementation of orbit / zoom. 

Note that currently neither orbit nor zoom supports their operation around a cursor, they operate directly on camera forward. So it will feel weird. 

Zoom / orbit to cursor will be added _soon_